### PR TITLE
Add + to locked balances

### DIFF
--- a/src/renderer/components/Sidebar/Balance.vue
+++ b/src/renderer/components/Sidebar/Balance.vue
@@ -11,12 +11,12 @@
         <div
             v-if="lockedXzc > 0 && pendingXzc > 0"
         >
-            (<amount :amount="lockedXzc" /> locked, <amount :amount="pendingXzc" /> pending)
+            (+ <amount :amount="lockedXzc" /> locked, <amount :amount="pendingXzc" /> pending)
         </div>
         <div
             v-else-if="lockedXzc > 0"
         >
-            (<amount :amount="lockedXzc" /> locked)
+            (+ <amount :amount="lockedXzc" /> locked)
         </div>
         <div
             v-else-if="pendingXzc > 0"

--- a/src/renderer/components/Sidebar/Balance.vue
+++ b/src/renderer/components/Sidebar/Balance.vue
@@ -29,7 +29,7 @@
             class="zerocoin-total"
         >
             <amount :amount="availableZerocoin" /> <span class="ticker" title="Private XZC">ⓩ</span>
-            (<amount :amount="unconfirmedZerocoin" /> pending)
+            (+ <amount :amount="unconfirmedZerocoin" /> pending)
         </div>
         <div
             v-else-if="availableZerocoin > 0"
@@ -41,7 +41,7 @@
             v-else-if="unconfirmedZerocoin > 0"
             class="zerocoin-total"
         >
-            (<amount :amount="unconfirmedZerocoin" /> <span class="ticker" title="Private XZC">ⓩ</span> pending)
+            (+ <amount :amount="unconfirmedZerocoin" /> <span class="ticker" title="Private XZC">ⓩ</span> pending)
         </div>
     </section>
 </template>


### PR DESCRIPTION
# Issue 

If you have one or more Znodes (or any locked coins) the balance will be shown as 

```
(<amount> locked)
```

# Proposal

In my opinion this doesn't clearly state whether the locked amount shown is included in the total balance or not. As it is - contrary to how it's displayed in the existing client - _not_ included, I propose to add `+` to the locked balance so it reads 

```
(+ <amount> locked)
``` 

# Alternative
An alternative option would be to add the locked coins to the total balance and print something like 

```
(including <amount> locked)
``` 