### PR TITLE
Add identity key for Mac in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
       ]
     },
     "mac": {
+      "identity": null,
       "icon": "assets/icons/icon.icns",
       "files": [
         "!assets/core/linux",


### PR DESCRIPTION
Currently every time I do a build I have to set the `identity` key to `null` under the `mac` entry in `package.json`. As far as I know, this is some authentication issue with Electron that requires this to be set. I propose we add it to the main repo for now, and review if it's necessary later, eg. when we do an official build.